### PR TITLE
ZDOTU Implementation

### DIFF
--- a/Include/CDC8600.hh
+++ b/Include/CDC8600.hh
@@ -291,7 +291,10 @@ namespace CDC8600
     call0 Call(void (*f)());
 
     template<typename T0>
-    func0<T0> Func(T0 (*f)());
+    func0<T0> Func(T0 (*f)())
+    {
+        return func0<T0>(f);
+    }
 
     template <typename T1, typename T2, typename T3, typename T4, typename T5>
     call5<T1, T2, T3, T4, T5> Call(void (*f)(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5))

--- a/Include/blas/zdotu.hh
+++ b/Include/blas/zdotu.hh
@@ -1,0 +1,16 @@
+#ifndef _zdotu_HH_
+#define _zdotu_HH_
+
+#include <CDC8600.hh>
+
+namespace CDC8600
+{
+    namespace BLAS
+    {
+        c128 zdotu    (u64 n, c128 *zx, i64 incx, c128 *zy, i64 incy);
+        c128 zdotu_cpp(u64 n, c128 *zx, i64 incx, c128 *zy, i64 incy);
+	void zdotu_asm();
+    } // namespace BLAS
+}; // namespace CDC8600
+
+#endif

--- a/Src/blas/zdotu.cc
+++ b/Src/blas/zdotu.cc
@@ -8,9 +8,7 @@ namespace CDC8600
     {
         c128 zdotu(u64 n, c128 *zx, i64 incx, c128 *zy, i64 incy)
         {
-            Func(zdotu_asm)(n, zx, incx, zy, incy);
-            // Current convention - returning result in X11 and X12 (bad)
-            return c128(PROC.X(11).f(), PROC.X(12).f());
+            return Func(zdotu_asm)(n, zx, incx, zy, incy);
         }
 
         c128 zdotu_cpp(u64 n, c128 *zx, i64 incx, c128 *zy, i64 incy)
@@ -77,7 +75,9 @@ LABEL(loop) jmpz(0, end)	// if X0 (n) = 0 goto end
 	    isjki(6, 6, 4)	// X6 (iy) = X6 (iy) + X4 (incy)
 	    idjkj(0, 1)		// X0 (n) = X0 (n) - 1
             jmp(loop)
-LABEL(end)  jmpk(15, 1)		// return to X15 (calling address) + 1
+LABEL(end)  isjki(1, 12, 0)     // Optimization, know X0=0, so X1 = X12
+            isjki(0, 11, 0)     // X0 = X11 + 0
+            jmpk(15,1)
             // clang-format on
         }
     } // namespace BLAS

--- a/Src/blas/zdotu.cc
+++ b/Src/blas/zdotu.cc
@@ -1,0 +1,84 @@
+#include <CDC8600.hh>
+#include <ISA.hh>
+#include <blas/zdotu.hh>
+
+namespace CDC8600
+{
+    namespace BLAS
+    {
+        c128 zdotu(u64 n, c128 *zx, i64 incx, c128 *zy, i64 incy)
+        {
+            Func(zdotu_asm)(n, zx, incx, zy, incy);
+            // Current convention - returning result in X11 and X12 (bad)
+            return c128(PROC.X(11).f(), PROC.X(12).f());
+        }
+
+        c128 zdotu_cpp(u64 n, c128 *zx, i64 incx, c128 *zy, i64 incy)
+        {
+            c128 ztemp = 0;
+
+	    i64 ix = 0;				// First element of zx
+	    i64 iy = 0;				// First element of zy
+	    if (incx <= 0) ix = (-n+1)*incx;	// If incx <= 0, start with last element of x
+	    if (incy <= 0) iy = (-n+1)*incy;	// If incy <= 0, start with last element of y
+	    while (n != 0)			// Any elements left?
+	    {
+                ztemp += zx[ix] * zy[iy];
+                ix += incx;
+                iy += incy;
+		n--;				// Decrement element count
+	    }
+
+            return ztemp;           
+        }
+
+	void zdotu_asm
+        (
+            // u64 n,           [ X0 ]
+            // c128 *zx,        [ X1 ]
+            // i64 incx,        [ X2 ]
+            // c128 *zy,        [ X3 ]
+            // i64 incy         [ X4 ]
+        )
+        {
+            // clang-format off
+	    isjki(2, 2, 2)	// X2 (incx) = 2*X2 (incx)
+            isjki(4, 4, 4)	// X4 (incy) = 2*X4 (incy)
+	    xkj(5, 0)		// X5 (ix) = 0
+	    xkj(6, 0)		// X6 (iy) = 0
+            xkj(11,0)           // X11(res-real) = 0
+            xkj(12,0)           // X12(res-imag) = 0
+	    jmpp(2, L1)		// if X2 (incx) > 0 goto L1
+	    idzkj(5, 0)		// X5 (ix) = -X0 (n)
+	    isjkj(5, 1)		// X5 (ix) = X5(-n) + 1
+            ipjkj(5, 2)		// X5 (ix) = X5 (-n+1) * X2 (incx)
+LABEL(L1)   jmpp(4, loop)	// if X4 (incy) > 0 goto loop
+	    idzkj(6, 0)		// X6 (iy) = -X0 (n)
+	    isjkj(6, 1)		// X6 (iy) = X6(-n) + 1
+            ipjkj(6, 4)		// X6 (iy) = X6 (-n+1) * X4 (incy)
+LABEL(loop) jmpz(0, end)	// if X0 (n) = 0 goto end
+            rdjki(7, 1, 5)	// X7 (tmp) = MEM[X1 (zx) + X5 (ix)] (real)
+            rdjki(9, 3, 6)	// X9 (tmp) = MEM[X3 (zx) + X6 (iy)] (real)
+	    isjkj(1, 1)		// X1 (zx) = X1 (zx) + 1
+	    isjkj(3, 1)		// X3 (zy) = X3 (zy) + 1
+            rdjki(8, 1, 5)	// X8 (tmp) = MEM[X1 (zx) + X5 (ix)] (imag)
+            rdjki(10, 3, 6)	// X10(tmp) = MEM[X3 (zx) + X6 (ix)] (imag)
+	    idjkj(1, 1)		// X1 (zx) = X1 (zx) - 1
+	    idjkj(3, 1)		// X3 (zy) = X3 (zy) - 1
+            fmul(13,7,9)        // X13(tmp) = X7 * X9
+            fadd(11,11,13)      // X11(res-real) = X11 + X13
+            fmul(13,8,10)       // X13(tmp) = X8 * X10
+            fsub(11,11,13)      // X11(res-real) = X11 - X13 (because imaginary)
+            fmul(13,7,10)       // X13(tmp) = X7 * X10
+            fadd(12,12,13)      // X12(res-imag) = X12 + X13
+            fmul(13,8,9)        // X13(tmp) = X8 * X9
+            fadd(12,12,13)      // X12(res-imag) = X12 + X13
+            isjki(5, 5, 2)	// X5 (ix) = X5 (ix) + X2 (incx)
+	    isjki(6, 6, 4)	// X6 (iy) = X6 (iy) + X4 (incy)
+	    idjkj(0, 1)		// X0 (n) = X0 (n) - 1
+            jmp(loop)
+LABEL(end)  jmpk(15, 1)		// return to X15 (calling address) + 1
+            // clang-format on
+        }
+    } // namespace BLAS
+} // namespace CDC8600

--- a/Tests/zdotu.cc
+++ b/Tests/zdotu.cc
@@ -1,0 +1,71 @@
+#include <blas/zdotu.hh>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <iomanip>
+#include <complex>
+
+using namespace CDC8600;
+
+extern "C" c128 zdotu_(i32*, c128*, i32*, c128*, i32*);
+
+const int N = 20;
+const double epsilon = pow(1, -9);
+
+void test_zcopy(int count)
+{
+    reset();
+
+    i32 n = rand() % 256;
+    i32 incx = (rand() % 16) - 8;
+    i32 incy = (rand() % 16) - 8;
+    u32 nx = n*abs(incx); if (0 == nx) nx = 1;
+    u32 ny = n*abs(incy); if (0 == ny) ny = 1;
+
+    c128 *x = (c128*)CDC8600::memalloc(nx*2);
+    c128 *y = (c128*)CDC8600::memalloc(ny*2);
+
+    for (int i = 0; i < nx; i++) { x[i] = c128(drand48(), drand48()); }
+    for (int i = 0; i < ny; i++) { y[i] = c128(drand48(), drand48()); }
+
+    c128 res_ref = zdotu_(&n, x, &incx, y, &incy);
+    c128 res_new = CDC8600::BLAS::zdotu(n, x, incx, y, incy);
+
+    bool pass = true;
+
+    // Have to check equality of both real and imag parts separately :/
+    double real_ref = res_ref.real();
+    double real_new = res_new.real();
+    double imag_ref = res_ref.imag();
+    double imag_new = res_new.imag();
+    if ((abs(real_ref - real_new) >
+          ((abs(real_ref) < abs(real_new) ? abs(real_ref) : abs(real_new)) +
+              epsilon) *
+         epsilon) ||
+        (abs(imag_ref - imag_new) >
+          ((abs(imag_ref) < abs(imag_new) ? abs(imag_ref) : abs(imag_new)) +
+              epsilon) *
+         epsilon))
+    {
+      pass = false;
+    }
+
+    /* cout << "zcopy [" << setw(2) << count << "] (n = " << setw(3) << n << ", incx = " << setw(2) << incx << ", incy = " << setw(2) << incy << ", # of instr = " << setw(9) << instructions::count << ") : "; */
+    if (pass)
+        cout << "PASS" << std::endl;
+    else
+        cout << "FAIL" << std::endl;
+
+    if (n < 10) dump(trace);
+}
+    
+
+int main()
+{
+    for (int i = 0; i < N; i++)
+    {
+        test_zcopy(i);
+    }
+    return 0;
+}

--- a/Tests/zdotu.cc
+++ b/Tests/zdotu.cc
@@ -13,7 +13,7 @@ extern "C" c128 zdotu_(i32*, c128*, i32*, c128*, i32*);
 const int N = 20;
 const double epsilon = pow(1, -9);
 
-void test_zcopy(int count)
+void test_zdotu(int count)
 {
     reset();
 
@@ -65,7 +65,7 @@ int main()
 {
     for (int i = 0; i < N; i++)
     {
-        test_zcopy(i);
+        test_zdotu(i);
     }
     return 0;
 }

--- a/Tests/zdotu.cc
+++ b/Tests/zdotu.cc
@@ -51,7 +51,7 @@ void test_zcopy(int count)
       pass = false;
     }
 
-    /* cout << "zcopy [" << setw(2) << count << "] (n = " << setw(3) << n << ", incx = " << setw(2) << incx << ", incy = " << setw(2) << incy << ", # of instr = " << setw(9) << instructions::count << ") : "; */
+    cout << "zdotu [" << setw(2) << count << "] (n = " << setw(3) << n << ", incx = " << setw(2) << incx << ", incy = " << setw(2) << incy << ", # of instr = " << setw(9) << instructions::count << ") : ";
     if (pass)
         cout << "PASS" << std::endl;
     else


### PR DESCRIPTION
Notably, I needed to have the return type of `zdotu_asm` be void because `jmpk` includes a `return;` statement. I tried to add a different instruction that would allow for `return 0;` (or some different trivial value), but this turned out to be a pain because of the macro names.

Includes what I think is a bug-fix to fix compilation (see #19)

Passes on my machine (x86 WSL Ubuntu)