### PR TITLE
Hw2 DROT optimization

### DIFF
--- a/Include/bb.hh
+++ b/Include/bb.hh
@@ -1,12 +1,12 @@
 class bb : public Fijk
 {
     public:
-	bb(u08 j, u08 k, u32 K) : Fijk(0x23, j, k, K) {}
+	bb(u08 j, u08 k) : Fijk(0xB, 0, j, k) {}
 
 	bool execute()
 	{
 	    if (PROC.X(_j).i() - PROC.X(_k).i() < 0) return true;
-            else return false;
+        else return false;
 	}
 
 	string mnemonic() const

--- a/Src/blas/drot.cc
+++ b/Src/blas/drot.cc
@@ -44,13 +44,40 @@ namespace CDC8600
 	)
 	{
             // Optimization 1: If n<=0, return right away.
-            // Jmp if zero
-            // Jmp if negative
-
+            // Jmp if zero or negative
+            jmpn(0, end);
+            jmpz(0, end);
+            
             // Optimization 2: If incx and incy is both 1, do the bb routine instead of the regular routine.
+            xkj(7, 0)		// X7 = 0
+            isjki(8, 7, 2);  // Move X2 to X8
+            idjkj(8, 1);     // X8 = X8 - 1
+            jmpnz(8, reg);
+            isjki(8, 7, 4);    // Move X4 to X8
+            idjkj(8, 1);
+            jmpnz(8, reg);
 
+            // The optimized routine (incx == incy == 1)
+LABEL(opt)  jmpz(0, end)
+            rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)]
+            rdjki(10, 3, 7)	// X10 (tmpy) = MEM[X3 (y) + X7 (iy)]
+            fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c
+            fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s
+            fadd(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) + X12 (tmp2)
+            sdjki(11, 1, 7)	// MEM[X1 (x) + X7 (ix)] = X11 (tmp1)
+            fmul(11, 5, 10)  	// X11 (tmp1) = X10 (tmpy) * c
+            fmul(12, 6, 9)   	// X12 (tmp2) = X9 (tmpx) * s
+            fsub(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) - X12 (tmp2)
+            sdjki(11, 3, 7)	// MEM[X3 (y) + X7 (iy)] = X11 (tmp11)
+            isjkj(7, 1)  // X7 = X7 + 1
+            // isjkj(7, 1)  // X7 = X7 + 1
+            // bb(0, 7, opt)
+            // jmp(end)
+            idjkj(0, 1) // X0 (n) = X0 (n) - 1
+            jmp(opt)
+            
             // clang-format off
-            xkj(7, 0)		// X7 (ix) = 0
+LABEL(reg)  xkj(7, 0)		// X7 (ix) = 0
             xkj(8, 0)		// X8 (iy) = 0
             jmpp(2, L1)		// if X2 (incx) > 0 goto L1
             idzkj(7, 0)		// X7 (ix) = -X0 (n)

--- a/Src/blas/drot.cc
+++ b/Src/blas/drot.cc
@@ -45,8 +45,8 @@ namespace CDC8600
 	{
             // Optimization 1: If n<=0, return right away.
             // Jmp if zero or negative
-            jmpn(0, end);
             jmpz(0, end);
+            jmpn(0, end);
             
             // Optimization 2: If incx and incy is both 1, do the bb routine instead of the regular routine.
             xkj(7, 0)		// X7 = 0
@@ -58,8 +58,7 @@ namespace CDC8600
             jmpnz(8, reg);
 
             // The optimized routine (incx == incy == 1)
-LABEL(opt)  jmpz(0, end)
-            rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)]
+LABEL(opt)  rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)]
             rdjki(10, 3, 7)	// X10 (tmpy) = MEM[X3 (y) + X7 (iy)]
             fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c
             fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s
@@ -70,11 +69,8 @@ LABEL(opt)  jmpz(0, end)
             fsub(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) - X12 (tmp2)
             sdjki(11, 3, 7)	// MEM[X3 (y) + X7 (iy)] = X11 (tmp11)
             isjkj(7, 1)  // X7 = X7 + 1
-            // isjkj(7, 1)  // X7 = X7 + 1
-            // bb(0, 7, opt)
-            // jmp(end)
-            idjkj(0, 1) // X0 (n) = X0 (n) - 1
-            jmp(opt)
+            bb(7, 0, opt)
+            jmp(end)
             
             // clang-format off
 LABEL(reg)  xkj(7, 0)		// X7 (ix) = 0

--- a/Src/blas/drot.cc
+++ b/Src/blas/drot.cc
@@ -43,6 +43,12 @@ namespace CDC8600
         // f64 s		[ X6 ]
 	)
 	{
+            // Optimization 1: If n<=0, return right away.
+            // Jmp if zero
+            // Jmp if negative
+
+            // Optimization 2: If incx and incy is both 1, do the bb routine instead of the regular routine.
+
             xkj(7, 0)		// X7 (ix) = 0
             xkj(8, 0)		// X8 (iy) = 0
             jmpp(2, L1)		// if X2 (incx) > 0 goto L1

--- a/Tests/drot.cc
+++ b/Tests/drot.cc
@@ -9,21 +9,26 @@ using namespace CDC8600;
 
 extern "C" int32_t drot_(int32_t *, double *, int32_t *, double *, int32_t *, double *, double *);
 
-const int N = 20;
+const int N = 25;
 
 void test_drot(int count)
 {
     reset();
 
-    // int32_t n = rand() % 256;
     int32_t n = rand() % 256;
+    if(count == 0)
+        n = 0; // Test for optimization when n = 0
     int32_t incx = (rand() % 16) - 8;
     int32_t incy = (rand() % 16) - 8;
+    if (count >= 20){ // Test for optimization when incx = 1 and incy = 1
+        incx = 1;
+        incy = 1;
+    }
     f64 angle = drand48() * (2 * M_PI);
     f64 c = cos(angle); // cos
     f64 s = sin(angle); // sin
-    int32_t nx = 1 + (n-1) * abs(incx); // not n * abs(incx)
-    int32_t ny = 1 + (n-1) * abs(incy); // not n * abs(incy)
+    int32_t nx = 1 + n * abs(incx); // not n * abs(incx)
+    int32_t ny = 1 + n * abs(incy); // not n * abs(incy)
 
     f64 *x = (f64*)CDC8600::memalloc(nx);
     f64 *y = (f64*)CDC8600::memalloc(ny);


### PR DESCRIPTION
* I am using the `bb.hh` of @lafis002 so that we don't have conflicts on the `bb` definition.
* Test setup:
  * Test 1 is to test `n == 0`.
  * Tests 2-20 are to test the normal routine.
  * Tests 21-25 are to test when `incx == 1 && incy == 1`.

Optimization number 1: (Actually this should not be kept, but was one of the optimizations the Forthan version did)
* If we have an input with `n == 0`, we do nothing and return right away.
* Results: # of instr 9->2, probably not worthwhile since it incurs 2 extra instructions for other cases. But we keep it in the submission just to illustrate the ideas.
    - Before optimization:
```drot [ 0] (n =   0, incx = -2, incy =  1, c =  1, s = 2.45546e-13, # of instr =         2) : PASS```
    - After optimization: 
```drot [ 0] (n =   0, incx = -2, incy =  1, c =  1, s = 2.45546e-13, # of instr =         9) : PASS```

Optimization number 2:
* If we have an input with `incx == 1` and` incy == 1`, we use branch back to use fewer instructions. This is a really common case since for most use cases, we are just doing a normal rotation, where we set `incx == 1` and `incy == 1`.
* Results: 20% fewer instructions were used for this particular case. This incurs 4 or 7 more instructions for each other case, but is generally acceptable since most cases have overall hundreds or thousands of instructions.
    - Before optimization:

  ```drot [20] (n =  33, incx =  1, incy =  1, c = -0.991268, s = -0.131866, # of instr =       501) : PASS
  drot [21] (n = 135, incx =  1, incy =  1, c = -0.978347, s = 0.206973, # of instr =      2031) : PASS
  drot [22] (n =  62, incx =  1, incy =  1, c = 0.279854, s = 0.960042, # of instr =       936) : PASS
  drot [23] (n = 225, incx =  1, incy =  1, c = 0.597602, s = 0.801793, # of instr =      3381) : PASS
  drot [24] (n =  62, incx =  1, incy =  1, c = -0.999033, s = -0.0439607, # of instr =       936) : PASS
  ```

  - After optimization: 
  ```drot [20] (n =  33, incx =  1, incy =  1, c = -0.991268, s = -0.131866, # of instr =       407) : PASS
  drot [21] (n = 135, incx =  1, incy =  1, c = -0.978347, s = 0.206973, # of instr =      1631) : PASS
  drot [22] (n =  62, incx =  1, incy =  1, c = 0.279854, s = 0.960042, # of instr =       755) : PASS
  drot [23] (n = 225, incx =  1, incy =  1, c = 0.597602, s = 0.801793, # of instr =      2711) : PASS
  drot [24] (n =  62, incx =  1, incy =  1, c = -0.999033, s = -0.0439607, # of instr =       755) : PASS
   ```