### PR TITLE
Fixed drot; Add operations for jmpn and bb.

### DIFF
--- a/Include/ISA.hh
+++ b/Include/ISA.hh
@@ -25,7 +25,7 @@
 
 #define jmpp(Xj,L)		if (process(new instructions::jmpp   (Xj,  #L), __LINE__)) goto L;
 
-#define jmpn(Xj,L)		if (process(new instructions::jmpn   (Xj,  0), __LINE__)) goto L;
+#define jmpn(Xj,L)		if (process(new instructions::jmpn   (Xj,  #L), __LINE__)) goto L;
 
 #define bb(Xj,Xk,L)		if (process(new instructions::bb     (Xj, Xk, #L), __LINE__)) goto L;
 

--- a/Include/ISA.hh
+++ b/Include/ISA.hh
@@ -27,7 +27,7 @@
 
 #define jmpn(Xj,L)		if (process(new instructions::jmpn   (Xj,  0), __LINE__)) goto L;
 
-#define bb(Xj,Xk,L)		if (process(new instructions::bb     (Xj, Xk), __LINE__)) goto L;
+#define bb(Xj,Xk,L)		if (process(new instructions::bb     (Xj, Xk, #L), __LINE__)) goto L;
 
 #define call(Xj,func)		if (process(new instructions::call   (Xj), __LINE__))     func ();
 

--- a/Include/instructions/bb.hh
+++ b/Include/instructions/bb.hh
@@ -1,7 +1,10 @@
 class bb : public Fijk
 {
+	private:
+	string	_label;
+
     public:
-	bb(u08 j, u08 k) : Fijk(0xB, 0, j, k) {}
+	bb(u08 j, u08 k, string L) : Fijk(0xB, 0, j, k) { _label = L; }
 
 	bool execute()
 	{
@@ -12,5 +15,24 @@ class bb : public Fijk
 	string mnemonic() const
 	{
 	    return "bb";
+	}
+
+	bool ops()
+	{
+		process(new operations::cmp(_j, _k));
+	    process(new operations::bb(_i));
+	    return false;
+	}
+	
+	void fixit()
+	{
+	    assert(label2line.count(_label));
+	    u32 targetline = label2line[_label];
+	    assert(line2addr.count(targetline));
+	    u32 targetaddr = line2addr[targetline];
+	    assert(line2addr.count(_line));
+	    u32 sourceaddr = line2addr[_line];
+	    _i = (sourceaddr/8) - (targetaddr/8); // Finally calculate and assert _i
+		assert(_i < 16);
 	}
 };

--- a/Include/instructions/bb.hh
+++ b/Include/instructions/bb.hh
@@ -19,7 +19,7 @@ class bb : public Fijk
 
 	bool ops()
 	{
-		process(new operations::cmp(_j, _k));
+	    process(new operations::cmp(_j, _k));
 	    process(new operations::bb(_i));
 	    return false;
 	}
@@ -33,6 +33,6 @@ class bb : public Fijk
 	    assert(line2addr.count(_line));
 	    u32 sourceaddr = line2addr[_line];
 	    _i = (sourceaddr/8) - (targetaddr/8); // Finally calculate and assert _i
-		assert(_i < 16);
+	    assert(_i < 16);
 	}
 };

--- a/Include/instructions/bb.hh
+++ b/Include/instructions/bb.hh
@@ -32,7 +32,7 @@ class bb : public Fijk
 	    u32 targetaddr = line2addr[targetline];
 	    assert(line2addr.count(_line));
 	    u32 sourceaddr = line2addr[_line];
-		assert(sourceaddr >= targetaddr);
+	    assert(sourceaddr >= targetaddr);
 	    _i = (sourceaddr/8) - (targetaddr/8); // Finally calculate and assert _i
 	    assert(_i < 16);
 	}

--- a/Include/instructions/bb.hh
+++ b/Include/instructions/bb.hh
@@ -32,6 +32,7 @@ class bb : public Fijk
 	    u32 targetaddr = line2addr[targetline];
 	    assert(line2addr.count(_line));
 	    u32 sourceaddr = line2addr[_line];
+		assert(sourceaddr >= targetaddr);
 	    _i = (sourceaddr/8) - (targetaddr/8); // Finally calculate and assert _i
 	    assert(_i < 16);
 	}

--- a/Include/instructions/jmpn.hh
+++ b/Include/instructions/jmpn.hh
@@ -1,7 +1,10 @@
 class jmpn : public FjK
 {
+    private:
+	string	_label;
+
     public:
-	jmpn(u08 j, u32 K) : FjK(0x37, j, K) {}
+	jmpn(u08 j, string L) : FjK(0x37, j, 0) { _label = L; }
 
 	bool execute()
 	{
@@ -12,5 +15,23 @@ class jmpn : public FjK
 	string mnemonic() const
 	{
 	    return "jmpn";
+	}
+	
+	bool ops()
+	{
+	    process(new operations::cmpz(_j));
+	    process(new operations::jmpn());
+	    return false;
+	}
+
+	void fixit()
+	{
+	    assert(label2line.count(_label));
+	    u32 targetline = label2line[_label];
+	    assert(line2addr.count(targetline));
+	    u32 targetaddr = line2addr[targetline];
+	    assert(line2addr.count(_line));
+	    u32 sourceaddr = line2addr[_line];
+	    _K = ((targetaddr/8) - (sourceaddr/8)) & 0xfffff;
 	}
 };

--- a/Include/operations.hh
+++ b/Include/operations.hh
@@ -374,7 +374,7 @@ namespace CDC8600
 		string dasm() const { return mnemonic() + "(" + ")"; }
 	};
 
-		class bb : public BRop
+	class bb : public BRop
 	{
 	    private:
 		u08	_i;

--- a/Include/operations.hh
+++ b/Include/operations.hh
@@ -360,6 +360,20 @@ namespace CDC8600
 		string dasm() const { return mnemonic() + "(" + ")"; }
 	};
 
+	class jmpn : public BRop
+	{
+	    private:
+
+	    public:
+		jmpn() { }
+		u64 ready() const { return REGready[params::micro::CMPFLAGS]; }
+		u64 target(u64 cycle) { nextdispatch = cycle; }
+		u64 latency() const { return 1; }
+		u64 throughput() const { return 1; }
+		string mnemonic() const { return "jmpn"; }
+		string dasm() const { return mnemonic() + "(" + ")"; }
+	};
+
 		class bb : public BRop
 	{
 	    private:

--- a/Include/operations.hh
+++ b/Include/operations.hh
@@ -290,7 +290,7 @@ namespace CDC8600
 	{
 	    private:
 	        u08 _j;
-			u08 _k;
+	        u08 _k;
 
 	    public:
 		cmp(u08 j, u08 k) { _j = j;  _k = k; }

--- a/Include/operations.hh
+++ b/Include/operations.hh
@@ -286,6 +286,22 @@ namespace CDC8600
 		string dasm() const { return mnemonic() + "(" + to_string(_j) + ")"; }
 	};
 
+	class cmp : public FXop
+	{
+	    private:
+	        u08 _j;
+			u08 _k;
+
+	    public:
+		cmp(u08 j, u08 k) { _j = j;  _k = k; }
+		u64 ready() const { return max(REGready[_j], REGready[_k]); }
+		u64 target(u64 cycle) { REGready[params::micro::CMPFLAGS] = cycle; }
+		u64 latency() const { return 1; }
+		u64 throughput() const { return 1; }
+		string mnemonic() const { return "cmp"; }
+		string dasm() const { return mnemonic() + "(" + to_string(_j) + ", " + to_string(_k) + ")"; }
+	};
+
 	class jmp : public BRop
 	{
 	    private:
@@ -342,6 +358,21 @@ namespace CDC8600
 		u64 throughput() const { return 1; }
 		string mnemonic() const { return "jmpp"; }
 		string dasm() const { return mnemonic() + "(" + ")"; }
+	};
+
+		class bb : public BRop
+	{
+	    private:
+		u08	_i;
+
+	    public:
+		bb(u08 i) { _i = i;}
+		u64 ready() const { return REGready[params::micro::CMPFLAGS]; }
+		u64 target(u64 cycle) { nextdispatch = cycle; }
+		u64 latency() const { return 1; }
+		u64 throughput() const { return 1; }
+		string mnemonic() const { return "bb"; }
+		string dasm() const { return mnemonic() + "(" + to_string(_i) + ")"; }
 	};
 
         class fadd : public FPop

--- a/Src/blas/drot.cc
+++ b/Src/blas/drot.cc
@@ -42,7 +42,7 @@ namespace CDC8600
         // f64 c		[ X5 ]
         // f64 s		[ X6 ]
 	)
-	{
+	    {
             // Optimization 1: If n<=0, return right away.
             // Jmp if zero or negative
             jmpz(0, end);                                               // 0

--- a/Src/blas/drot.cc
+++ b/Src/blas/drot.cc
@@ -43,63 +43,70 @@ namespace CDC8600
         // f64 s		[ X6 ]
 	)
 	{
-            // Optimization 1: If n<=0, return right away.
-            // Jmp if zero or negative
-            jmpz(0, end);
-            jmpn(0, end);
+//             // Optimization 1: If n<=0, return right away.
+//             // Jmp if zero or negative
+//             jmpz(0, end);
+//             jmpn(0, end);
             
-            // Optimization 2: If incx and incy is both 1, do the bb routine instead of the regular routine.
-            xkj(7, 0)		// X7 = 0
-            isjki(8, 7, 2);  // Move X2 to X8
-            idjkj(8, 1);     // X8 = X8 - 1
-            jmpnz(8, reg);
-            isjki(8, 7, 4);    // Move X4 to X8
-            idjkj(8, 1);
-            jmpnz(8, reg);
+//             // Optimization 2: If incx and incy is both 1, do the bb routine instead of the regular routine.
+//             xkj(7, 0)		// X7 = 0
+//             isjki(8, 7, 2);  // Move X2 to X8
+//             idjkj(8, 1);     // X8 = X8 - 1
+//             jmpnz(8, reg);
+//             isjki(8, 7, 4);    // Move X4 to X8
+//             idjkj(8, 1);
+//             jmpnz(8, reg);
 
-            // The optimized routine (incx == incy == 1)
-LABEL(opt)  rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)]
-            rdjki(10, 3, 7)	// X10 (tmpy) = MEM[X3 (y) + X7 (iy)]
-            fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c
-            fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s
-            fadd(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) + X12 (tmp2)
-            sdjki(11, 1, 7)	// MEM[X1 (x) + X7 (ix)] = X11 (tmp1)
-            fmul(11, 5, 10)  	// X11 (tmp1) = X10 (tmpy) * c
-            fmul(12, 6, 9)   	// X12 (tmp2) = X9 (tmpx) * s
-            fsub(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) - X12 (tmp2)
-            sdjki(11, 3, 7)	// MEM[X3 (y) + X7 (iy)] = X11 (tmp11)
-            isjkj(7, 1)  // X7 = X7 + 1
-            bb(7, 0, opt)
-            jmp(end)
+//             // The optimized routine (incx == incy == 1)
+// LABEL(opt)  rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)]
+//             rdjki(10, 3, 7)	// X10 (tmpy) = MEM[X3 (y) + X7 (iy)]
+//             fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c
+//             fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s
+//             fadd(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) + X12 (tmp2)
+//             sdjki(11, 1, 7)	// MEM[X1 (x) + X7 (ix)] = X11 (tmp1)
+//             fmul(11, 5, 10)  	// X11 (tmp1) = X10 (tmpy) * c
+//             fmul(12, 6, 9)   	// X12 (tmp2) = X9 (tmpx) * s
+//             fsub(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) - X12 (tmp2)
+//             sdjki(11, 3, 7)	// MEM[X3 (y) + X7 (iy)] = X11 (tmp11)
+//             isjkj(7, 1)  // X7 = X7 + 1
+//             bb(7, 0, opt)
+//             jmp(end)
             
             // clang-format off
-LABEL(reg)  xkj(7, 0)		// X7 (ix) = 0
-            xkj(8, 0)		// X8 (iy) = 0
-            jmpp(2, L1)		// if X2 (incx) > 0 goto L1
-            idzkj(7, 0)		// X7 (ix) = -X0 (n)
-            isjkj(7, 1)		// X7 (ix) = X7(-n) + 1
-            ipjkj(7, 2)		// X7 (ix) = X7 (-n+1) * X2 (incx)
-LABEL(L1)   jmpp(4, loop)	// if X4 (incy) > 0 goto loop
-            idzkj(8, 0)		// X8 (iy) = -X0 (n)
-            isjkj(8, 1)		// X8 (iy) = X8(-n) + 1
-            ipjkj(8, 4)		// X8 (iy) = X8 (-n+1) * X4 (incy)
-LABEL(loop) jmpz(0, end)	// if X0 (n) = 0 goto end
-            rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)]
-            rdjki(10, 3, 8)	// X10 (tmpy) = MEM[X3 (y) + X8 (iy)]
-            fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c
-            fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s
-            fadd(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) + X12 (tmp2)
-            sdjki(11, 1, 7)	// MEM[X1 (x) + X7 (ix)] = X11 (tmp1)
-            fmul(11, 5, 10)  	// X11 (tmp1) = X10 (tmpy) * c
-            fmul(12, 6, 9)   	// X12 (tmp2) = X9 (tmpx) * s
-            fsub(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) - X12 (tmp2)
-            sdjki(11, 3, 8)	// MEM[X3 (y) + X8 (iy)] = X11 (tmp11)
-            isjki(7, 7, 2)	// X7 (ix) = X7 (ix) + X2 (incx)
-            isjki(8, 8, 4)	// X8 (iy) = X8 (iy) + X4 (incy)
-	    idjkj(0, 1)		// X0 (n) = X0 (n) - 1
-            jmp(loop)
-LABEL(end)  jmpk(15, 1)		// return to X15 (calling address) + 1
+LABEL(reg)  xkj(7, 0)		// X7 (ix) = 0 // 0
+            xkj(8, 0)		// X8 (iy) = 0 // 2
+            jmpp(2, L1)		// if X2 (incx) > 0 goto L1 // 4
+            idzkj(7, 0)		// X7 (ix) = -X0 (n) // 8
+            isjkj(7, 1)		// X7 (ix) = X7(-n) + 1 // 10
+            ipjkj(7, 2)		// X7 (ix) = X7 (-n+1) * X2 (incx) // 12
+        pass() // 14
+LABEL(L1)   jmpp(4, loop)	// if X4 (incy) > 0 goto loop // 16
+            idzkj(8, 0)		// X8 (iy) = -X0 (n) // 20
+            isjkj(8, 1)		// X8 (iy) = X8(-n) + 1 // 22
+            ipjkj(8, 4)		// X8 (iy) = X8 (-n+1) * X4 (incy) // 24
+        pass() // 26
+        pass() // 28
+        pass() // 30
+LABEL(loop) jmpz(0, end)	// if X0 (n) = 0 goto end // 32
+            rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)] // 36
+            rdjki(10, 3, 8)	// X10 (tmpy) = MEM[X3 (y) + X8 (iy)] // 38
+            fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c // 40
+            fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s // 42
+            fadd(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) + X12 (tmp2) // 44
+            sdjki(11, 1, 7)	// MEM[X1 (x) + X7 (ix)] = X11 (tmp1) // 46
+            fmul(11, 5, 10)  	// X11 (tmp1) = X10 (tmpy) * c // 48
+            fmul(12, 6, 9)   	// X12 (tmp2) = X9 (tmpx) * s // 50
+            fsub(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) - X12 (tmp2) // 52
+            sdjki(11, 3, 8)	// MEM[X3 (y) + X8 (iy)] = X11 (tmp11) // 54
+            isjki(7, 7, 2)	// X7 (ix) = X7 (ix) + X2 (incx) // 56
+            isjki(8, 8, 4)	// X8 (iy) = X8 (iy) + X4 (incy) // 58
+	    idjkj(0, 1)		// X0 (n) = X0 (n) - 1 // 60
+        pass() // 62
+            jmp(loop) // 64
+        pass() // 68
+        pass() // 70
+LABEL(end)  jmpk(15, 1)		// return to X15 (calling address) + 1 // 72
             // clang-format on
-	}
+	    }
     } // namespace BLAS
 } // namespace CDC8600

--- a/Src/blas/drot.cc
+++ b/Src/blas/drot.cc
@@ -45,72 +45,71 @@ namespace CDC8600
 	{
             // Optimization 1: If n<=0, return right away.
             // Jmp if zero or negative
-            jmpz(0, end); // 0
-            jmpn(0, end); // 4
+            jmpz(0, end);                                               // 0
+            jmpn(0, end);                                               // 4
             
             // Optimization 2: If incx and incy is both 1, do the bb routine instead of the regular routine.
-            xkj(7, 0)		// X7 = 0 // 8
-            isjki(8, 7, 2);  // Move X2 to X8 // 10
-            idjkj(8, 1);     // X8 = X8 - 1 // 12
-            pass() // 14
-            jmpnz(8, reg); // 16
-            isjki(8, 7, 4);    // Move X4 to X8 // 20
-            idjkj(8, 1); // 22
-            jmpnz(8, reg); // 24
-            pass() // 28
-            pass() // 30
+            xkj(7, 0)		// X7 = 0                                   // 8
+            isjki(8, 7, 2);  // Move X2 to X8                           // 10
+            idjkj(8, 1);     // X8 = X8 - 1                             // 12
+            pass()                                                      // 14
+            jmpnz(8, reg);                                              // 16
+            isjki(8, 7, 4);    // Move X4 to X8                         // 20
+            idjkj(8, 1);                                                // 22
+            jmpnz(8, reg);                                              // 24
+            pass()                                                      // 28
+            pass()                                                      // 30
 
             // The optimized routine (incx == incy == 1)
-LABEL(opt)  rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)] // 32
-            rdjki(10, 3, 7)	// X10 (tmpy) = MEM[X3 (y) + X7 (iy)] // 34
-            fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c // 36
-            fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s // 38
+LABEL(opt)  rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)]        // 32
+            rdjki(10, 3, 7)	// X10 (tmpy) = MEM[X3 (y) + X7 (iy)]       // 34
+            fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c           // 36
+            fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s          // 38
             fadd(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) + X12 (tmp2) // 40
-            sdjki(11, 1, 7)	// MEM[X1 (x) + X7 (ix)] = X11 (tmp1) // 42
-            fmul(11, 5, 10)  	// X11 (tmp1) = X10 (tmpy) * c // 44
-            fmul(12, 6, 9)   	// X12 (tmp2) = X9 (tmpx) * s // 46
+            sdjki(11, 1, 7)	// MEM[X1 (x) + X7 (ix)] = X11 (tmp1)       // 42
+            fmul(11, 5, 10)  	// X11 (tmp1) = X10 (tmpy) * c          // 44
+            fmul(12, 6, 9)   	// X12 (tmp2) = X9 (tmpx) * s           // 46
             fsub(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) - X12 (tmp2) // 48
-            sdjki(11, 3, 7)	// MEM[X3 (y) + X7 (iy)] = X11 (tmp11) // 50
-            isjkj(7, 1)  // X7 = X7 + 1 // 52
-            bb(7, 0, opt) // 54
-            jmp(end) // 56
-            pass() // 60
-            pass() // 62
-            
+            sdjki(11, 3, 7)	// MEM[X3 (y) + X7 (iy)] = X11 (tmp11)      // 50
+            isjkj(7, 1)  // X7 = X7 + 1                                 // 52
+            bb(7, 0, opt)                                               // 54
+            jmp(end)                                                    // 56
+            pass()                                                      // 60
+            pass()                                                      // 62
             // clang-format off
-LABEL(reg)  xkj(7, 0)		// X7 (ix) = 0 // 64 (of optimized routine) // 0 (of regular routine)
-            xkj(8, 0)		// X8 (iy) = 0 // 2
-            jmpp(2, L1)		// if X2 (incx) > 0 goto L1 // 4
-            idzkj(7, 0)		// X7 (ix) = -X0 (n) // 8
-            isjkj(7, 1)		// X7 (ix) = X7(-n) + 1 // 10
-            ipjkj(7, 2)		// X7 (ix) = X7 (-n+1) * X2 (incx) // 12
-        pass() // 14
-LABEL(L1)   jmpp(4, loop)	// if X4 (incy) > 0 goto loop // 16
-            idzkj(8, 0)		// X8 (iy) = -X0 (n) // 20
-            isjkj(8, 1)		// X8 (iy) = X8(-n) + 1 // 22
-            ipjkj(8, 4)		// X8 (iy) = X8 (-n+1) * X4 (incy) // 24
-        pass() // 26
-        pass() // 28
-        pass() // 30
-LABEL(loop) jmpz(0, end)	// if X0 (n) = 0 goto end // 32
-            rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)] // 36
-            rdjki(10, 3, 8)	// X10 (tmpy) = MEM[X3 (y) + X8 (iy)] // 38
-            fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c // 40
-            fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s // 42
+LABEL(reg)  xkj(7, 0)		// X7 (ix) = 0                              // 64 (of optimized routine) // 0 (of regular routine)
+            xkj(8, 0)		// X8 (iy) = 0                              // 2
+            jmpp(2, L1)		// if X2 (incx) > 0 goto L1                 // 4
+            idzkj(7, 0)		// X7 (ix) = -X0 (n)                        // 8
+            isjkj(7, 1)		// X7 (ix) = X7(-n) + 1                     // 10
+            ipjkj(7, 2)		// X7 (ix) = X7 (-n+1) * X2 (incx)          // 12
+            pass()                                                      // 14
+LABEL(L1)   jmpp(4, loop)	// if X4 (incy) > 0 goto loop               // 16
+            idzkj(8, 0)		// X8 (iy) = -X0 (n)                        // 20
+            isjkj(8, 1)		// X8 (iy) = X8(-n) + 1                     // 22
+            ipjkj(8, 4)		// X8 (iy) = X8 (-n+1) * X4 (incy)          // 24
+            pass()                                                      // 26
+            pass()                                                      // 28
+            pass()                                                      // 30
+LABEL(loop) jmpz(0, end)	// if X0 (n) = 0 goto end                   // 32
+            rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)]        // 36
+            rdjki(10, 3, 8)	// X10 (tmpy) = MEM[X3 (y) + X8 (iy)]       // 38
+            fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c           // 40
+            fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s          // 42
             fadd(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) + X12 (tmp2) // 44
-            sdjki(11, 1, 7)	// MEM[X1 (x) + X7 (ix)] = X11 (tmp1) // 46
-            fmul(11, 5, 10)  	// X11 (tmp1) = X10 (tmpy) * c // 48
-            fmul(12, 6, 9)   	// X12 (tmp2) = X9 (tmpx) * s // 50
+            sdjki(11, 1, 7)	// MEM[X1 (x) + X7 (ix)] = X11 (tmp1)       // 46
+            fmul(11, 5, 10)  	// X11 (tmp1) = X10 (tmpy) * c          // 48
+            fmul(12, 6, 9)   	// X12 (tmp2) = X9 (tmpx) * s           // 50
             fsub(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) - X12 (tmp2) // 52
-            sdjki(11, 3, 8)	// MEM[X3 (y) + X8 (iy)] = X11 (tmp11) // 54
-            isjki(7, 7, 2)	// X7 (ix) = X7 (ix) + X2 (incx) // 56
-            isjki(8, 8, 4)	// X8 (iy) = X8 (iy) + X4 (incy) // 58
-	    idjkj(0, 1)		// X0 (n) = X0 (n) - 1 // 60
-        pass() // 62
-            jmp(loop) // 64
-        pass() // 68
-        pass() // 70
-LABEL(end)  jmpk(15, 1)		// return to X15 (calling address) + 1 // 72
+            sdjki(11, 3, 8)	// MEM[X3 (y) + X8 (iy)] = X11 (tmp11)      // 54
+            isjki(7, 7, 2)	// X7 (ix) = X7 (ix) + X2 (incx)            // 56
+            isjki(8, 8, 4)	// X8 (iy) = X8 (iy) + X4 (incy)            // 58
+	        idjkj(0, 1)		// X0 (n) = X0 (n) - 1                      // 60
+            pass()                                                      // 62
+            jmp(loop)                                                   // 64
+            pass()                                                      // 68
+            pass()                                                      // 70
+LABEL(end)  jmpk(15, 1)		// return to X15 (calling address) + 1      // 72
             // clang-format on
 	    }
     } // namespace BLAS

--- a/Src/blas/drot.cc
+++ b/Src/blas/drot.cc
@@ -43,37 +43,42 @@ namespace CDC8600
         // f64 s		[ X6 ]
 	)
 	{
-//             // Optimization 1: If n<=0, return right away.
-//             // Jmp if zero or negative
-//             jmpz(0, end);
-//             jmpn(0, end);
+            // Optimization 1: If n<=0, return right away.
+            // Jmp if zero or negative
+            jmpz(0, end); // 0
+            jmpn(0, end); // 4
             
-//             // Optimization 2: If incx and incy is both 1, do the bb routine instead of the regular routine.
-//             xkj(7, 0)		// X7 = 0
-//             isjki(8, 7, 2);  // Move X2 to X8
-//             idjkj(8, 1);     // X8 = X8 - 1
-//             jmpnz(8, reg);
-//             isjki(8, 7, 4);    // Move X4 to X8
-//             idjkj(8, 1);
-//             jmpnz(8, reg);
+            // Optimization 2: If incx and incy is both 1, do the bb routine instead of the regular routine.
+            xkj(7, 0)		// X7 = 0 // 8
+            isjki(8, 7, 2);  // Move X2 to X8 // 10
+            idjkj(8, 1);     // X8 = X8 - 1 // 12
+            pass() // 14
+            jmpnz(8, reg); // 16
+            isjki(8, 7, 4);    // Move X4 to X8 // 20
+            idjkj(8, 1); // 22
+            jmpnz(8, reg); // 24
+            pass() // 28
+            pass() // 30
 
-//             // The optimized routine (incx == incy == 1)
-// LABEL(opt)  rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)]
-//             rdjki(10, 3, 7)	// X10 (tmpy) = MEM[X3 (y) + X7 (iy)]
-//             fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c
-//             fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s
-//             fadd(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) + X12 (tmp2)
-//             sdjki(11, 1, 7)	// MEM[X1 (x) + X7 (ix)] = X11 (tmp1)
-//             fmul(11, 5, 10)  	// X11 (tmp1) = X10 (tmpy) * c
-//             fmul(12, 6, 9)   	// X12 (tmp2) = X9 (tmpx) * s
-//             fsub(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) - X12 (tmp2)
-//             sdjki(11, 3, 7)	// MEM[X3 (y) + X7 (iy)] = X11 (tmp11)
-//             isjkj(7, 1)  // X7 = X7 + 1
-//             bb(7, 0, opt)
-//             jmp(end)
+            // The optimized routine (incx == incy == 1)
+LABEL(opt)  rdjki(9, 1, 7)	// X9 (tmpx) = MEM[X1 (x) + X7 (ix)] // 32
+            rdjki(10, 3, 7)	// X10 (tmpy) = MEM[X3 (y) + X7 (iy)] // 34
+            fmul(11, 5, 9)   	// X11 (tmp1) = X9 (tmpx) * c // 36
+            fmul(12, 6, 10)  	// X12 (tmp2) = X10 (tmpy) * s // 38
+            fadd(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) + X12 (tmp2) // 40
+            sdjki(11, 1, 7)	// MEM[X1 (x) + X7 (ix)] = X11 (tmp1) // 42
+            fmul(11, 5, 10)  	// X11 (tmp1) = X10 (tmpy) * c // 44
+            fmul(12, 6, 9)   	// X12 (tmp2) = X9 (tmpx) * s // 46
+            fsub(11, 11, 12) 	// X11 (tmp1) = X11 (tmp1) - X12 (tmp2) // 48
+            sdjki(11, 3, 7)	// MEM[X3 (y) + X7 (iy)] = X11 (tmp11) // 50
+            isjkj(7, 1)  // X7 = X7 + 1 // 52
+            bb(7, 0, opt) // 54
+            jmp(end) // 56
+            pass() // 60
+            pass() // 62
             
             // clang-format off
-LABEL(reg)  xkj(7, 0)		// X7 (ix) = 0 // 0
+LABEL(reg)  xkj(7, 0)		// X7 (ix) = 0 // 64 (of optimized routine) // 0 (of regular routine)
             xkj(8, 0)		// X8 (iy) = 0 // 2
             jmpp(2, L1)		// if X2 (incx) > 0 goto L1 // 4
             idzkj(7, 0)		// X7 (ix) = -X0 (n) // 8

--- a/Tests/drot.cc
+++ b/Tests/drot.cc
@@ -30,6 +30,8 @@ void test_drot(int count)
     int32_t nx = 1 + n * abs(incx); // not n * abs(incx)
     int32_t ny = 1 + n * abs(incy); // not n * abs(incy)
 
+    tracing = false; if (n < 10) tracing = true;
+
     f64 *x = (f64*)CDC8600::memalloc(nx);
     f64 *y = (f64*)CDC8600::memalloc(ny);
     f64 *X = new f64[nx];
@@ -61,7 +63,14 @@ void test_drot(int count)
     delete [] X;
     delete [] Y;
 
-    cout << "drot [" << setw(2) << count << "] (n = " << setw(3) << n << ", incx = " << setw(2) << incx << ", incy = " << setw(2) << incy << ", c = " << setw(2) << c << ", s = " << setw(2) << s << ", # of instr = " << setw(9) << instructions::count <<  ") : ";
+    cout << "drot [" << setw(2)<< count << "] ";
+    cout << "(n = " << setw(3) << n;
+    cout << ", incx = " << setw(2) << incx;
+    cout << ", incy = " << setw(2) << incy;
+    cout << ", c = " << setw(2) << c << ", s = " << setw(2) << s;
+    cout << ", # of instr = " << setw(9) << instructions::count;
+    cout << ", # of cycles = " << setw(9) << operations::maxcycle;
+    cout <<  ") : ";
     if (pass)
         cout << "PASS" << std::endl;
     else


### PR DESCRIPTION
My routine also uses `jmpnz`, but since @pxhuangxyl already defined it, I'm not going to do repetitive work.

`jmpn` is similar to `jmpp`.

The `bb` instruction can be broken down into `cmp` (also newly defined) and `bb` operations. `cmp` is just an operation to compare 2 registers, and also uses the `CMPFLAGS`.

Since it's hard to "go back some lines" in C++, I still use labels to "go back". To ensure that `bb` will only go back, and can only go back less than 16 words, I added the following lines to `fixit()`.

```
assert(sourceaddr >= targetaddr);
_i = (sourceaddr/8) - (targetaddr/8); // Finally calculate and assert _i
assert(_i < 16);
```