### PR TITLE
dtrmv_ltu

### DIFF
--- a/Include/blas/dtrmv_ltu.hh
+++ b/Include/blas/dtrmv_ltu.hh
@@ -7,8 +7,8 @@ namespace CDC8600
 {
     namespace BLAS
     {
-        void dtrmv_ltu    (u64 n, f64 *A, u64 lda, f64 *x, i64 incx);
-        void dtrmv_ltu_cpp(u64 n, f64 *A, u64 lda, f64 *x, i64 incx);
+        void dtrmv_ltu    (i64 n, f64 *A, i64 lda, f64 *x, i64 incx);
+        void dtrmv_ltu_cpp(i64 n, f64 *A, i64 lda, f64 *x, i64 incx);
         // void dtrmv_ltu_asm();
     } // namespace BLAS
 }; // namespace CDC8600

--- a/Include/blas/dtrmv_ltu.hh
+++ b/Include/blas/dtrmv_ltu.hh
@@ -1,0 +1,16 @@
+#ifndef _dtrmv_ltu_HH_
+#define _dtrmv_ltu_HH_
+
+#include <CDC8600.hh>
+
+namespace CDC8600
+{
+    namespace BLAS
+    {
+        void dtrmv_ltu    (u64 n, f64 *A, u64 lda, f64 *x, i64 incx);
+        void dtrmv_ltu_cpp(u64 n, f64 *A, u64 lda, f64 *x, i64 incx);
+        // void dtrmv_ltu_asm();
+    } // namespace BLAS
+}; // namespace CDC8600
+
+#endif

--- a/Src/blas/dtrmv_ltu.cc
+++ b/Src/blas/dtrmv_ltu.cc
@@ -1,0 +1,21 @@
+#include <CDC8600.hh>
+#include <ISA.hh>
+#include <blas/dtrmv_ltu.hh>
+#include <blas/dcopy.hh>
+
+namespace CDC8600
+{
+    namespace BLAS
+    {
+        void dtrmv_ltu(u64 n, f64 *A, u64 lda, f64 *x, i64 incx)
+        {
+            Call(dtrmv_ltu_cpp)(n, A, lda, x, incx);
+        }
+
+        void dtrmv_ltu_cpp(u64 n, f64 *A, u64 lda, f64 *x, i64 incx)
+        {
+            // Input check
+            return;
+        }
+    } // namespace BLAS
+} // namespace CDC8600

--- a/Src/blas/dtrmv_ltu.cc
+++ b/Src/blas/dtrmv_ltu.cc
@@ -7,12 +7,12 @@ namespace CDC8600
 {
     namespace BLAS
     {
-        void dtrmv_ltu(u64 n, f64 *A, u64 lda, f64 *x, i64 incx)
+        void dtrmv_ltu(i64 n, f64 *A, i64 lda, f64 *x, i64 incx)
         {
             Call(dtrmv_ltu_cpp)(n, A, lda, x, incx);
         }
 
-        void dtrmv_ltu_cpp(u64 n, f64 *A, u64 lda, f64 *x, i64 incx)
+        void dtrmv_ltu_cpp(i64 n, f64 *A, i64 lda, f64 *x, i64 incx)
         {
             // Input check
             return;

--- a/Src/blas/dtrmv_ltu.cc
+++ b/Src/blas/dtrmv_ltu.cc
@@ -1,7 +1,7 @@
 #include <CDC8600.hh>
 #include <ISA.hh>
 #include <blas/dtrmv_ltu.hh>
-#include <blas/dcopy.hh>
+#include <blas/ddot.hh>
 
 namespace CDC8600
 {
@@ -15,7 +15,13 @@ namespace CDC8600
         void dtrmv_ltu_cpp(i64 n, f64 *A, i64 lda, f64 *x, i64 incx)
         {
             // Input check
-            return;
+            if (n <= 0 || incx == 0 || lda <= 0 || lda < n)
+                return;
+            i64 ix = (incx <= 0) ? (-n + 1) * incx : 0;
+            for (i64 i = 0; i < n; i++) {
+                x[ix] = x[ix] + ddot(n - i - 1,  A + lda * i + i + 1, 1, (incx < 0) ? x : x + ix + incx, incx);
+                ix += incx;
+            }
         }
     } // namespace BLAS
 } // namespace CDC8600

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -1,5 +1,5 @@
 BLAS_1		= dcopy zcopy drot zdrot zaxpy dscal zdotu zswap ddot zdotc idamax dasum zscal daxpy dswap
-BLAS_2		= dtrans dtrmv_unn dgemv_ta dger dtrmv_ltu dtrmv_lnu dgemv_td
+BLAS_2		= dtrans dger dgemv_nd dgemv_na dgemv_td dgemv_ta dtrmv_unu dtrmv_utu dtrmv_lnu dtrmv_ltu dtrmv_unn dtrmv_utn dtrmv_lnn dtrmv_ltn
 BLAS		= ${BLAS_1} ${BLAS_2}
 TESTS 		= ${BLAS}
 CCC			= g++

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -1,5 +1,5 @@
 BLAS_1		= dcopy zcopy drot zdrot zaxpy dscal zdotu zswap ddot zdotc idamax dasum zscal daxpy dswap
-BLAS_2		= dtrans dtrmv_unn dgemv_ta
+BLAS_2		= dtrans dtrmv_unn dgemv_ta dtrmv_ltu
 BLAS		= ${BLAS_1} ${BLAS_2}
 TESTS 		= ${BLAS}
 CCC			= g++
@@ -33,6 +33,9 @@ dtrmv_unn:	dtrmv_unn.cc ../Src/blas/dtrmv_unn.cc ../Src/blas/ddot.cc ../Include/
 
 dgemv_ta:	dgemv_ta.cc ../Src/blas/dgemv_ta.cc ../Src/blas/daxpy.cc ../Src/blas/dscal.cc ../Include/blas/daxpy.hh ../Include/blas/dscal.hh ../Include/blas/dgemv_ta.hh blasref
 	${CCC} ${CCFLAGS} ${OMPFLAGS} ${SRC_DEPS} dgemv_ta.cc ../Src/blas/dgemv_ta.cc ../Src/blas/daxpy.cc ../Src/blas/dscal.cc ../Blas/*.o ${FLIBS} -lgfortran -o $@
+
+dtrmv_ltu:	dtrmv_ltu.cc ../Src/blas/dtrmv_ltu.cc ../Src/blas/ddot.cc ../Include/blas/ddot.hh ../Include/blas/dtrmv_ltu.hh blasref
+	${CCC} ${CCFLAGS} ${OMPFLAGS} ${SRC_DEPS} dtrmv_ltu.cc ../Src/blas/dtrmv_ltu.cc ../Src/blas/ddot.cc ../Blas/*.o ${FLIBS} -lgfortran -o $@
 
 clean:
 	/bin/rm -rf ${TESTS}

--- a/Tests/drot.cc
+++ b/Tests/drot.cc
@@ -68,15 +68,15 @@ void test_drot(int count)
     cout << ", incx = " << setw(2) << incx;
     cout << ", incy = " << setw(2) << incy;
     cout << ", c = " << setw(2) << c << ", s = " << setw(2) << s;
-    cout << ", # of instr = " << setw(9) << instructions::count;
-    cout << ", # of cycles = " << setw(9) << operations::maxcycle;
+    cout << ", # of instr = " << setw(9) << PROC[0].instr_count;
+    cout << ", # of cycles = " << setw(9) << PROC[0].op_maxcycle;
     cout <<  ") : ";
     if (pass)
         cout << "PASS" << std::endl;
     else
         cout << "FAIL" << std::endl;
     
-    if (n < 10) dump(trace);
+    if (n < 10) dump(PROC[0].trace);
 }
 
 int main()

--- a/Tests/dtrmv_ltu.cc
+++ b/Tests/dtrmv_ltu.cc
@@ -11,8 +11,57 @@ extern "C" int32_t dtrmv_(char *, char *, char *, int32_t *, double *, int32_t *
 
 const u32 N = 20;
 
-void test_dcopy(int count)
+void test_dtrmv_ltu(int count)
 {
+    reset();
+
+    i32 n = rand() % 256;
+    i32 lda = n + rand() % 256;
+    i32 incx = (rand() % 16) - 8; // incx = 0?
+    incx = (incx == 0) ? 1:incx;
+    char uplo = 'L';
+    char trans = 'T';
+    char diag = 'U';
+
+    tracing = false; if (n < 10) tracing = true;
+
+    int32_t nx = 1 + n * abs(incx);
+
+    f64 *A = (f64*)CDC8600::memalloc(n*lda);
+    f64 *x = (f64*)CDC8600::memalloc(nx);
+    f64 *X = new f64[nx];
+
+    for (int i = 0; i < nx; i++) { X[i] = x[i] = drand48(); }
+    for (int i = 0; i < n*lda; i++) { A[i] = drand48(); }
+
+    dtrmv_(&uplo, &trans, &diag, &n, A, &lda, X, &incx);
+    CDC8600::BLAS::dtrmv_ltu(n, A, lda, x, incx);
+
+    bool pass = true;
+    for (int i = 0; i < nx; i++)
+    {
+        if (x[i] != X[i])
+        {
+            pass = false;
+        }
+    }
+
+    delete [] X;
+
+    cout << "dtrmv_ltu [" << setw(2)<< count << "] ";
+    cout << "(n = " << setw(3) << n;
+    cout << ", lda = " << setw(3) << lda;
+    cout << ", incx = " << setw(2) << incx;
+    cout << ", # of instr = " << setw(9) << PROC[0].instr_count;
+    cout << ", # of cycles = " << setw(9) << PROC[0].op_maxcycle;
+    cout <<  ") : ";
+    if (pass)
+        cout << "PASS" << std::endl;
+    else
+        cout << "FAIL" << std::endl;
+    
+    if (n < 10) dump(PROC[0].trace);
+
 
     return;
 }
@@ -21,7 +70,7 @@ int main()
 {
     for (u32 i = 0; i < N; i++)
     {
-        test_dcopy(i);
+        test_dtrmv_ltu(i);
     }
     return 0;
 }

--- a/Tests/dtrmv_ltu.cc
+++ b/Tests/dtrmv_ltu.cc
@@ -1,0 +1,13 @@
+#include <blas/dtrmv_ltu.hh>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <iomanip>
+
+using namespace CDC8600;
+
+int main()
+{
+    return 0;
+}

--- a/Tests/dtrmv_ltu.cc
+++ b/Tests/dtrmv_ltu.cc
@@ -7,7 +7,21 @@
 
 using namespace CDC8600;
 
+extern "C" int32_t dtrmv_(char *, char *, char *, int32_t *, double *, int32_t *, double *, int32_t *);
+
+const u32 N = 20;
+
+void test_dcopy(int count)
+{
+
+    return;
+}
+
 int main()
 {
+    for (u32 i = 0; i < N; i++)
+    {
+        test_dcopy(i);
+    }
     return 0;
 }

--- a/Tests/dtrmv_ltu.cc
+++ b/Tests/dtrmv_ltu.cc
@@ -10,6 +10,7 @@ using namespace CDC8600;
 extern "C" int32_t dtrmv_(char *, char *, char *, int32_t *, double *, int32_t *, double *, int32_t *);
 
 const u32 N = 20;
+const double EPSILON = 1e-9;
 
 void test_dtrmv_ltu(int count)
 {
@@ -17,13 +18,14 @@ void test_dtrmv_ltu(int count)
 
     i32 n = rand() % 256;
     i32 lda = n + rand() % 256;
+    lda = max(lda, 1);
     i32 incx = (rand() % 16) - 8; // incx = 0?
     incx = (incx == 0) ? 1:incx;
     char uplo = 'L';
     char trans = 'T';
     char diag = 'U';
 
-    tracing = false; if (n < 10) tracing = true;
+    // tracing = false; if (n < 10) tracing = true;
 
     int32_t nx = 1 + n * abs(incx);
 
@@ -40,9 +42,10 @@ void test_dtrmv_ltu(int count)
     bool pass = true;
     for (int i = 0; i < nx; i++)
     {
-        if (x[i] != X[i])
+        if(!(abs(X[i] - x[i]) < (min(abs(X[i]), abs(x[i])) + EPSILON) * EPSILON))
         {
             pass = false;
+            break;
         }
     }
 
@@ -60,7 +63,7 @@ void test_dtrmv_ltu(int count)
     else
         cout << "FAIL" << std::endl;
     
-    if (n < 10) dump(PROC[0].trace);
+    // if (n < 10) dump(PROC[0].trace);
 
 
     return;


### PR DESCRIPTION
dtrmv_ltu() implementation with ddot(). I also updated the Makefile's `BLAS_2` variable so that we won't have merge conflicts.

Test output:
```
dtrmv_ltu [ 0] (n = 103, lda = 301, incx =  1, # of instr =     63963, # of cycles =     54768) : PASS
dtrmv_ltu [ 1] (n = 115, lda = 196, incx =  7, # of instr =     79695, # of cycles =     68831) : PASS
dtrmv_ltu [ 2] (n =  74, lda = 310, incx =  1, # of instr =     33078, # of cycles =     28327) : PASS
dtrmv_ltu [ 3] (n = 205, lda = 391, incx =  3, # of instr =    252765, # of cycles =    214137) : PASS
dtrmv_ltu [ 4] (n = 242, lda = 493, incx = -5, # of instr =    353562, # of cycles =    299577) : PASS
dtrmv_ltu [ 5] (n =  70, lda = 194, incx = -6, # of instr =     30030, # of cycles =     26148) : PASS
dtrmv_ltu [ 6] (n =  84, lda = 332, incx =  3, # of instr =     42588, # of cycles =     36901) : PASS
dtrmv_ltu [ 7] (n = 232, lda = 463, incx =  5, # of instr =    323640, # of cycles =    275067) : PASS
dtrmv_ltu [ 8] (n = 118, lda = 208, incx =  6, # of instr =     83898, # of cycles =     72529) : PASS
dtrmv_ltu [ 9] (n =  99, lda = 150, incx =  7, # of instr =     59103, # of cycles =     51425) : PASS
dtrmv_ltu [10] (n = 201, lda = 355, incx = -2, # of instr =    244215, # of cycles =    207294) : PASS
dtrmv_ltu [11] (n =  50, lda =  63, incx = -1, # of instr =     15450, # of cycles =     13331) : PASS
dtrmv_ltu [12] (n =  49, lda = 137, incx = -5, # of instr =     14847, # of cycles =     13140) : PASS
dtrmv_ltu [13] (n =  90, lda = 127, incx =  5, # of instr =     48870, # of cycles =     42601) : PASS
dtrmv_ltu [14] (n =   5, lda =  28, incx =  1, # of instr =       165, # of cycles =       233) : PASS
dtrmv_ltu [15] (n = 233, lda = 327, incx = -4, # of instr =    327831, # of cycles =    277897) : PASS
dtrmv_ltu [16] (n = 171, lda = 349, incx =  5, # of instr =    175959, # of cycles =    150534) : PASS
dtrmv_ltu [17] (n = 198, lda = 353, incx = -4, # of instr =    237006, # of cycles =    201448) : PASS
dtrmv_ltu [18] (n =  84, lda = 101, incx =  6, # of instr =     42588, # of cycles =     37239) : PASS
dtrmv_ltu [19] (n = 130, lda = 246, incx = -7, # of instr =    102570, # of cycles =     87910) : PASS
```