### PR TITLE
Cleaned dgemv and finished HW5

### DIFF
--- a/Src/blas/dgemv_nd.cc
+++ b/Src/blas/dgemv_nd.cc
@@ -20,10 +20,9 @@ namespace CDC8600
                 return;
             }
 
-            dscal(m, beta, y, abs(incy)); // only works with abs(incy), 
-            //I assume this accidentally scales as  y := alpha*A*x - beta*y instead of y := alpha*A*x + beta*y
+            dscal(m, beta, y, abs(incy)); 
+            // NOTE, due to the positive only nature of dscal, above only works with abs(incy), 
         
-            // Adjust starting point based on incy
             u64 yIndex;
             if (incy > 0) {
                 yIndex = 0; // For positive incy, start at the beginning
@@ -33,18 +32,13 @@ namespace CDC8600
             if(incy > 0){
                 for (yIndex = 0; yIndex < m; ++yIndex) {
                     // y index goes through the rows, and saves at specific locations
-                    //printf("accessing y[%ld], yIndex %ld\n", yIndex * incy, yIndex);
-                    //beginning                           row 
                     y[yIndex * incy] += alpha * ddot(n, a + yIndex, lda, x, incx);
                 }
             } else {
-                for (i32 i = 0; i < m; ++i) {
-                    //printf("BEFORE y[%ld] = %f\n", yIndex, y[yIndex]);
+                for (u64 i = 0; i < m; ++i) {
                     // goes from accessing y[MAX DIMENSION] using row MAX_ROW-1 to the baseline
                     // inverse of positive case
-                    // printf("accessing y[%ld], yIndex %d\n", yIndex, i);
                     y[yIndex] += alpha * ddot(n, x, incx, a + i, lda);
-                    //printf("AFTER y[%ld] = %f\n", yIndex, y[yIndex]);
                     yIndex -= abs(incy);
                 }
             }

--- a/Src/blas/dgemv_nd.cc
+++ b/Src/blas/dgemv_nd.cc
@@ -30,16 +30,17 @@ namespace CDC8600
                 yIndex = (m - 1) * abs(incy); // For negative incy, start at the end
             }
             if(incy > 0){
+                #pragma omp parallel for 
                 for (yIndex = 0; yIndex < m; ++yIndex) {
                     // y index goes through the rows, and saves at specific locations
                     y[yIndex * incy] += alpha * ddot(n, a + yIndex, lda, x, incx);
                 }
             } else {
+                u64 yStart = (m - 1) * abs(incy);
+                #pragma omp parallel for
                 for (u64 i = 0; i < m; ++i) {
-                    // goes from accessing y[MAX DIMENSION] using row MAX_ROW-1 to the baseline
-                    // inverse of positive case
-                    y[yIndex] += alpha * ddot(n, x, incx, a + i, lda);
-                    yIndex -= abs(incy);
+                    u64 yIndex = yStart - i * abs(incy);   
+                    y[yIndex] += alpha * ddot(n, a + i, lda, x, incx);
                 }
             }
         }

--- a/Tests/dgemv_nd.cc
+++ b/Tests/dgemv_nd.cc
@@ -1,9 +1,10 @@
-#include <blas/dgemv_nd.hh>  // Make sure to include the correct header file
+#include <blas/dgemv_nd.hh>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <iomanip>
+#include <omp.h>
 
 using namespace CDC8600;
 
@@ -11,6 +12,29 @@ extern "C" i32 dgemv_(char *, i32 *, i32 *, f64 *, f64 *, i32 *, f64 *, i32 *, f
 
 const int N = 20;
 const double epsilon = std::pow(10, -6);
+const int NUM_THREADS = 4;
+bool PRETTY_PRINT_CORES = true;
+
+// Global variables to store total instructions and cycles
+uint64_t totalInstructions = 0;
+uint64_t totalCycles = 0;
+uint64_t maxInstructions = 0;
+uint64_t maxCycles = 0;
+
+void printPerformanceMetrics(int coreCount, bool pass) {
+    std::cout << std::left << std::setfill(' '); // Align text to the left and set fill character
+    // Print headers
+    std::cout << std::setw(10) << "Core" << std::setw(20) << "# of Instructions" << std::setw(20) << "# of Cycles" << std::setw(10) << "Result" << std::endl;
+    std::cout << std::setfill('-') << std::setw(60) << "" << std::setfill(' ') << std::endl; // Print a dividing line
+
+    for (int i = 0; i < coreCount; ++i) {
+        std::cout << std::setw(10) << i; // Print core number
+        std::cout << std::setw(20) << PROC[i].instr_count; // Print number of instructions
+        std::cout << std::setw(20) << PROC[i].op_maxcycle; // Print number of cycles
+        std::cout << std::setw(10) << (pass ? "PASS" : "FAIL") << std::endl; // Print pass/fail
+    }
+    printf("\n");
+}
 
 void test_dgemv_nd(int count) {
     reset();
@@ -53,27 +77,62 @@ void test_dgemv_nd(int count) {
 
     }
 
-    cout << "dgemv_nd [" << setw(2) << count << "] ";
-    cout << "(m = " << setw(3) << m;
-    cout << ", n = " << setw(3) << n;
-    cout << ", alpha = " << setw(5) << alpha;
-    cout << ", lda = " << setw(2) << lda;
-    cout << ", incx = " << setw(2) << incx;
-    cout << ", beta = " << setw(5) << beta;
-    cout << ", incy = " << setw(2) << incy;
-    cout << ", # of instr = " << setw(9) << PROC[0].instr_count;
-    cout << ", # of cycles = " << setw(9) << PROC[0].op_maxcycle;
-    cout << ") : ";
+    if (PRETTY_PRINT_CORES){
+        printf("RUN %i \n", count);
+        printPerformanceMetrics(params::Proc::N, pass);
+    } else {
+        cout << "dgemv_nd [" << setw(2) << count << "] ";
+        cout << "(m = " << setw(3) << m;
+        cout << ", n = " << setw(3) << n;
+        //cout << ", alpha = " << setw(2) << alpha;
+        //cout << ", LDA = " << setw(2) << LDA;
+        //cout << ", incx = " << setw(2) << incx;
+        //cout << ", beta = " << setw(2) << beta;
+        //cout << ", incy = " << setw(2) << incy;
+        cout << ", # of instr = ";
+        for (u32 p = 0; p < params::Proc::N; p++) cout << setw(9) << PROC[p].instr_count;
+        cout << ", # of cycles = ";
+        for (u32 p = 0; p < params::Proc::N; p++) cout << setw(9) << PROC[p].op_maxcycle;
+        cout << ") : ";
 
-    if (pass)
-        cout << "PASS" << std::endl;
-    else
-        cout << "FAIL" << std::endl;
+        if (pass)
+            cout << "PASS" << std::endl;
+        else
+            cout << "FAIL" << std::endl;
+    }
+
+    // Update global total instructions and cycles
+    for (u32 p = 0; p < params::Proc::N; p++) {
+        totalInstructions += PROC[p].instr_count;
+        totalCycles += PROC[p].op_maxcycle;
+
+        // Update max instructions and cycles
+        if (PROC[p].instr_count > maxInstructions) {
+            maxInstructions = PROC[p].instr_count;
+        }
+        if (PROC[p].op_maxcycle > maxCycles) {
+            maxCycles = PROC[p].op_maxcycle;
+        }
+    }
 }
 
 int main() {
     for (int i = 0; i < N; i++) {
         test_dgemv_nd(i);
     }
+
+    // Calculate averages
+    int usedCores = (PRETTY_PRINT_CORES) ? params::Proc::N : NUM_THREADS;
+    double avgInstructions = static_cast<double>(totalInstructions) / usedCores / N;
+    double avgCycles = static_cast<double>(totalCycles) / usedCores / N;
+
+    // Print averages
+    std::cout << "Average Instructions per Core: " << avgInstructions << std::endl;
+    std::cout << "Average Cycles per Core: " << avgCycles << std::endl;
+
+    // Print max instructions and cycles
+    std::cout << "Max Instructions: " << maxInstructions << std::endl;
+    std::cout << "Max Cycles: " << maxCycles << std::endl;
+
     return 0;
 }

--- a/Tests/dgemv_nd.cc
+++ b/Tests/dgemv_nd.cc
@@ -49,7 +49,6 @@ void test_dgemv_nd(int count) {
         if (abs(y[i] - y_[i]) > (min(abs(y[i]), abs(y_[i])) + epsilon) * epsilon)
 	{
             pass = false;
-            //std::cerr << "Mismatch at " << i << ": got " << y_[i] << ", expected " << y[i] << std::endl;
         }
 
     }


### PR DESCRIPTION
Response to https://github.com/comse6998/spring2024/issues/87

The code properly optimizes HW5 dgemv_nd (negative cases of incy were a problem again). The unit test also toggles between a really useful per-core cycle/instruction pretty print with other useful info like max cycle/instruction count and average count per core. this is able to be turned off by just setting bool PRETTY_PRINT_CORES = false; in the unit test