### PR TITLE
dtrmv_ltu parallelization

### DIFF
--- a/Src/blas/dtrmv_ltu.cc
+++ b/Src/blas/dtrmv_ltu.cc
@@ -2,6 +2,8 @@
 #include <ISA.hh>
 #include <blas/dtrmv_ltu.hh>
 #include <blas/ddot.hh>
+#include <blas/dcopy.hh>
+// #include <cstring>
 
 namespace CDC8600
 {
@@ -17,11 +19,38 @@ namespace CDC8600
             // Input check
             if (n <= 0 || incx == 0 || lda <= 0 || lda < n)
                 return;
-            i64 ix = (incx <= 0) ? (-n + 1) * incx : 0;
-            for (i64 i = 0; i < n; i++) {
-                x[ix] = x[ix] + ddot(n - i - 1,  A + lda * i + i + 1, 1, (incx < 0) ? x : x + ix + incx, incx);
-                ix += incx;
+            u64 nx = (n-1) * abs(incx) + 1;
+            f64 *tempx = (f64*)CDC8600::memalloc(n);
+
+            // memcpy(tempx, x, nx * sizeof(f64)); // Not good, not tracked.
+            
+            // dcopy(n, x, 1, tempx, 1);
+            // dcopy(n, x, incx, tempx, 1);
+
+            #pragma omp parallel
+            {
+                dcopy((n / nump()) + (me() < n % nump()),
+                (x + abs(incx) * me()),
+                abs (incx) * nump(),
+                tempx + me(),
+                nump());
             }
+            
+
+            // #pragma omp parallel
+            // {
+            //     dcopy()
+            // }
+
+            #pragma omp parallel
+            {
+                for  (i64 i = me(); i < n - 1; i += nump()) {
+                    i64 ix;
+                    ix = (incx <= 0) ? (-n + 1 + i) * incx : (i * incx);
+                    x[ix] = x[ix] + ddot(n - i - 1,  A + lda * i + i + 1, 1, (incx > 0) ? (tempx + i + 1) : tempx, (incx > 0) ? 1 : (-1));
+                }
+            }
+            
         }
     } // namespace BLAS
 } // namespace CDC8600

--- a/Src/blas/dtrmv_ltu.cc
+++ b/Src/blas/dtrmv_ltu.cc
@@ -19,38 +19,38 @@ namespace CDC8600
             // Input check
             if (n <= 0 || incx == 0 || lda <= 0 || lda < n)
                 return;
-            u64 nx = (n-1) * abs(incx) + 1;
             f64 *tempx = (f64*)CDC8600::memalloc(n);
 
             // memcpy(tempx, x, nx * sizeof(f64)); // Not good, not tracked.
             
             // dcopy(n, x, 1, tempx, 1);
             // dcopy(n, x, incx, tempx, 1);
-
+            // dcopy(n, x, incx, tempx, (incx > 0) ? 1 : (-1));
+            
             #pragma omp parallel
             {
-                dcopy((n / nump()) + (me() < n % nump()),
-                (x + abs(incx) * me()),
-                abs (incx) * nump(),
-                tempx + me(),
-                nump());
+                if (nump() > 1)
+                    dcopy((n / nump()) + (me() < n % nump()),
+                    (x + abs(incx) * me()),
+                    abs(incx) * nump(),
+                    tempx + me(),
+                    nump());
             }
             
-
-            // #pragma omp parallel
-            // {
-            //     dcopy()
-            // }
-
             #pragma omp parallel
             {
                 for  (i64 i = me(); i < n - 1; i += nump()) {
                     i64 ix;
                     ix = (incx <= 0) ? (-n + 1 + i) * incx : (i * incx);
-                    x[ix] = x[ix] + ddot(n - i - 1,  A + lda * i + i + 1, 1, (incx > 0) ? (tempx + i + 1) : tempx, (incx > 0) ? 1 : (-1));
+                    if (nump() > 1)
+                        x[ix] = x[ix] + ddot(n - i - 1,  A + lda * i + i + 1, 1, (incx > 0) ? (tempx + i + 1) : tempx, (incx > 0) ? 1 : (-1));
+                    else
+                        x[ix] = x[ix] + ddot(n - i - 1,  A + lda * i + i + 1, 1, (incx < 0) ? x : x + ix + incx, incx);
+
                 }
             }
-            
+
+            // How to free memory?
         }
     } // namespace BLAS
 } // namespace CDC8600

--- a/Src/blas/dtrmv_ltu.cc
+++ b/Src/blas/dtrmv_ltu.cc
@@ -3,7 +3,6 @@
 #include <blas/dtrmv_ltu.hh>
 #include <blas/ddot.hh>
 #include <blas/dcopy.hh>
-// #include <cstring>
 
 namespace CDC8600
 {
@@ -37,6 +36,7 @@ namespace CDC8600
             
             #pragma omp parallel
             {
+                // Cyclic partition
                 for  (i64 i = me(); i < n - 1; i += nump()) {
                     i64 ix;
                     ix = (incx <= 0) ? (-n + 1 + i) * incx : (i * incx);
@@ -47,8 +47,22 @@ namespace CDC8600
                         x[ix] = x[ix] + ddot(n - i - 1,  A + lda * i + i + 1, 1,
                             (incx < 0) ? x : x + ix + incx, incx);
                     }
-
                 }
+                
+                // block-wise partition
+                /*
+                for  (i64 i = (n-1) / nump() * me() ; i < ((me() == nump() - 1) ? (n - 1) : ((n - 1) / nump() * (me() + 1))); i += 1) {
+                    i64 ix;
+                    ix = (incx <= 0) ? (-n + 1 + i) * incx : (i * incx);
+                    if (nump() > 1) {
+                        x[ix] = x[ix] + ddot(n - i - 1,  A + lda * i + i + 1, 1,
+                            (incx > 0) ? (tempx + i + 1) : tempx, (incx > 0) ? 1 : (-1));
+                    } else {
+                        x[ix] = x[ix] + ddot(n - i - 1,  A + lda * i + i + 1, 1,
+                            (incx < 0) ? x : x + ix + incx, incx);
+                    }
+                }
+                */
             }
 
             CDC8600::memfree(tempx, n);

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -61,8 +61,8 @@ dgemv_na:   dgemv_ta.cc ../Src/blas/dgemv_na.cc ../Src/blas/daxpy.cc ../Include/
 dgemv_ta:	dgemv_ta.cc ../Src/blas/dgemv_ta.cc ../Src/blas/daxpy.cc ../Src/blas/dscal.cc ../Include/blas/daxpy.hh ../Include/blas/dscal.hh ../Include/blas/dgemv_ta.hh blasref
 	${CCC} ${CCFLAGS} ${OMPFLAGS} ${SRC_DEPS} dgemv_ta.cc ../Src/blas/dgemv_ta.cc ../Src/blas/daxpy.cc ../Src/blas/dscal.cc ../Blas/*.o ${FLIBS} -lgfortran -o $@
 
-dtrmv_ltu:	dtrmv_ltu.cc ../Src/blas/dtrmv_ltu.cc ../Src/blas/ddot.cc ../Include/blas/ddot.hh ../Include/blas/dtrmv_ltu.hh blasref
-	${CCC} ${CCFLAGS} ${OMPFLAGS} ${SRC_DEPS} dtrmv_ltu.cc ../Src/blas/dtrmv_ltu.cc ../Src/blas/ddot.cc ../Blas/*.o ${FLIBS} -lgfortran -o $@
+dtrmv_ltu:	dtrmv_ltu.cc ../Src/blas/dtrmv_ltu.cc ../Src/blas/ddot.cc ../Include/blas/ddot.hh ../Include/blas/dtrmv_ltu.hh ../Src/blas/dcopy.cc ../Include/blas/dcopy.hh blasref
+	${CCC} ${CCFLAGS} ${OMPFLAGS} ${SRC_DEPS} dtrmv_ltu.cc ../Src/blas/dtrmv_ltu.cc ../Src/blas/ddot.cc ../Src/blas/dcopy.cc ../Blas/*.o ${FLIBS} -lgfortran -o $@
 
 dgemv_td:	dgemv_td.cc ../Src/blas/dgemv_td.cc ../Src/blas/ddot.cc ../Src/blas/dscal.cc ../Include/blas/daxpy.hh ../Include/blas/dscal.hh ../Include/blas/dgemv_td.hh blasref
 	${CCC} ${CCFLAGS} ${OMPFLAGS} ${SRC_DEPS} dgemv_td.cc ../Src/blas/dgemv_td.cc ../Src/blas/ddot.cc ../Src/blas/dscal.cc ../Blas/*.o ${FLIBS} -lgfortran -o $@

--- a/Tests/dtrmv_ltu.cc
+++ b/Tests/dtrmv_ltu.cc
@@ -55,9 +55,11 @@ void test_dtrmv_ltu(int count)
     cout << "(n = " << setw(3) << n;
     cout << ", lda = " << setw(3) << lda;
     cout << ", incx = " << setw(2) << incx;
-    cout << ", # of instr = " << setw(9) << PROC[0].instr_count;
-    cout << ", # of cycles = " << setw(9) << PROC[0].op_maxcycle;
-    cout <<  ") : ";
+    cout << ", # of instr = " << setw(9);
+    for (u32 p = 0; p < params::Proc::N; p++) cout << setw(9) << PROC[p].instr_count;
+    cout << ", # of cycles = ";
+    for (u32 p = 0; p < params::Proc::N; p++) cout << setw(9) << PROC[p].op_maxcycle;
+    cout << ") : ";
     if (pass)
         cout << "PASS" << std::endl;
     else

--- a/Tests/dtrmv_ltu.cc
+++ b/Tests/dtrmv_ltu.cc
@@ -24,6 +24,9 @@ void test_dtrmv_ltu(int count)
     char uplo = 'L';
     char trans = 'T';
     char diag = 'U';
+    u64 total_cycles = 0;
+    u64 max_cycles = 0;
+    u64 num_procs = 0;
 
     // tracing = false; if (n < 10) tracing = true;
 
@@ -56,9 +59,19 @@ void test_dtrmv_ltu(int count)
     cout << ", lda = " << setw(3) << lda;
     cout << ", incx = " << setw(2) << incx;
     cout << ", # of instr = " << setw(9);
-    for (u32 p = 0; p < params::Proc::N; p++) cout << setw(9) << PROC[p].instr_count;
+    for (u32 p = 0; p < params::Proc::N; p++) {
+        cout << setw(9) << PROC[p].instr_count;
+    }
     cout << ", # of cycles = ";
-    for (u32 p = 0; p < params::Proc::N; p++) cout << setw(9) << PROC[p].op_maxcycle;
+    for (u32 p = 0; p < params::Proc::N; p++) {
+        cout << setw(9) << PROC[p].op_maxcycle;
+        if (PROC[p].op_maxcycle > 0) {
+            num_procs++;
+            max_cycles = max(max_cycles, PROC[p].op_maxcycle);
+            total_cycles += PROC[p].op_maxcycle;
+        }
+    }
+    cout << ", max cycles = " << setw(9) << max_cycles  << ", total cycles = " << setw(9) << total_cycles << ", avg cycles = " <<  setw(9) << total_cycles / (1.0 * num_procs);
     cout << ") : ";
     if (pass)
         cout << "PASS" << std::endl;
@@ -66,9 +79,8 @@ void test_dtrmv_ltu(int count)
         cout << "FAIL" << std::endl;
     
     // if (n < 10) dump(PROC[0].trace);
-
-
-    return;
+    CDC8600::memfree(x, nx);
+    CDC8600::memfree(A, n*lda);
 }
 
 int main()


### PR DESCRIPTION
3 parallelization methods:
* with OpenMP barrier `#pragma omp barrier`, partially sync the progress of each CPU and save the intermediate result in a temporary local f64 variable
* Block-wise partitioning with a temp vector. Also parallelize dcopy. 
* Cyclic partitioning with a temp vector. Also parallelize dcopy. 

Modified the test file for design space exploration.