### PR TITLE
Add pipe_t::NOP

### DIFF
--- a/Include/operations.hh
+++ b/Include/operations.hh
@@ -34,7 +34,7 @@ namespace CDC8600
 		 virtual string dasm() const = 0;				// operation disassembly with physical registers
 		 virtual vector<units::unit>& units() = 0;			// the units that can execute this operation
 		 virtual    u64 encode() const { return 0; }			// 64-bit encoding of the operation
-		 virtual pipes::pipe_t pipe() const { return pipes::FXArith; }	// execution pipe for this operation
+		 virtual pipes::pipe_t pipe() const { return pipes::NOP; }	// execution pipe for this operation
 		 virtual pipes::dep_t dep() const { return pipes::no_dep; }	// type of dependence for this operation
 
 		 virtual   void dump(ostream &out)			// operation trace
@@ -118,7 +118,7 @@ namespace CDC8600
 		(
 		)
 		{
-		    return pipes::FXArith;
+		    return pipes::NOP;
 		}
 
 		virtual pipes::dep_t dep

--- a/Include/types.hh
+++ b/Include/types.hh
@@ -192,6 +192,7 @@ namespace CDC8600
     {
 	typedef enum
 	{
+        NOP,
 	    BR,
 	    ST,
 	    LD,

--- a/Include/types.hh
+++ b/Include/types.hh
@@ -192,7 +192,7 @@ namespace CDC8600
     {
 	typedef enum
 	{
-        NOP,
+	    NOP,
 	    BR,
 	    ST,
 	    LD,

--- a/Src/CDC8600.cc
+++ b/Src/CDC8600.cc
@@ -1004,7 +1004,7 @@ namespace CDC8600
 		case CDC8600::pipes::j_dep  : return (PROC[me()].Pfull[jreg]);				// depends on j register
 		case CDC8600::pipes::jk_dep : return (PROC[me()].Pfull[jreg] & PROC[me()].Pfull[kreg]);	// depends on j and k registers
 		case CDC8600::pipes::no_dep : return true;						// no dependences
-		default 		    		: assert(false);						// should not happen
+		default 		    : assert(false);						// should not happen
 	    }
 
 	    return false;

--- a/Src/CDC8600.cc
+++ b/Src/CDC8600.cc
@@ -1580,12 +1580,6 @@ namespace CDC8600
 			transfer(96, A1, 0, A2, 0*96);
 			transfer(96, A0, 0, A1, 0*96);
 
-			// cout << "FPStage::tick(): F for operations: " << endl;
-			// cout << pipes::F(in) << endl;
-
-			// cout << operations::mappers[pipes::F(in)]->pipe();
-			// cout << endl;
-
 			switch(operations::mappers[pipes::F(in)]->pipe())
 			{
 				case CDC8600::pipes::FPMul:
@@ -1596,10 +1590,9 @@ namespace CDC8600
 					transfer(96, RF, 0, D0, 0); break;
 				case  CDC8600::pipes::NOP:
 					// Should not assert false here, since default for no-op is FXArith
-					// Also, shouldn't just break, this will stuck the pipeline
+					// Also, shouldn't just break, this will congest the pipeline
 					transfer(96, RF, 0, M0, 0); break;
 				default:
-					// cout << endl << operations::mappers[pipes::F(in)]->pipe() << endl;
 					assert(false);
 			}
 

--- a/Src/CDC8600.cc
+++ b/Src/CDC8600.cc
@@ -1004,7 +1004,7 @@ namespace CDC8600
 		case CDC8600::pipes::j_dep  : return (PROC[me()].Pfull[jreg]);				// depends on j register
 		case CDC8600::pipes::jk_dep : return (PROC[me()].Pfull[jreg] & PROC[me()].Pfull[kreg]);	// depends on j and k registers
 		case CDC8600::pipes::no_dep : return true;						// no dependences
-		default 		    : assert(false);						// should not happen
+		default 		    		: assert(false);						// should not happen
 	    }
 
 	    return false;
@@ -1071,6 +1071,7 @@ namespace CDC8600
 													break;
 					case CDC8600::pipes::BR:
 					case CDC8600::pipes::ST:
+					case CDC8600::pipes::NOP:
 					case CDC8600::pipes::LD:		copy(96, opsq[i], 0, out, 0);	// copy operation i to output
 													opsq.erase(opsq.begin() + i);	// dequeue operation i
 													break;
@@ -1104,6 +1105,7 @@ namespace CDC8600
 			case CDC8600::pipes::FPAdd:
 			case CDC8600::pipes::FPMul:
 			case CDC8600::pipes::FPDiv: for (u32 i=0; i<in.size(); i++) out[2*96 + i] = in[i]; break;
+			case CDC8600::pipes::NOP: break; // output is already all zeros.
 			default : assert(false); 	// this should not happen
 	      }
 	      rxdone = false; rxready = true;
@@ -1139,6 +1141,7 @@ namespace CDC8600
 			case CDC8600::pipes::FXArith: transfer(96, RF, 0, A0, 0); break;
 			case CDC8600::pipes::FXMul:	  transfer(96, RF, 0, M0, 0); break;
 			case CDC8600::pipes::FXLogic: transfer(96, RF, 0, L0, 0); break;
+			case CDC8600::pipes::NOP: transfer(96, RF, 0, A0, 0); break;
 			default : assert(false); 	// this should not happen
 	    }
 		   
@@ -1591,10 +1594,13 @@ namespace CDC8600
 					transfer(96, RF, 0, A0, 0); break;
 				case CDC8600::pipes::FPDiv:
 					transfer(96, RF, 0, D0, 0); break;
-				default:
+				case  CDC8600::pipes::NOP:
 					// Should not assert false here, since default for no-op is FXArith
 					// Also, shouldn't just break, this will stuck the pipeline
 					transfer(96, RF, 0, M0, 0); break;
+				default:
+					// cout << endl << operations::mappers[pipes::F(in)]->pipe() << endl;
+					assert(false);
 			}
 
 			copy(96, in, 0, RF.in, 0);   RF.rxdone = true;
@@ -1630,7 +1636,7 @@ namespace CDC8600
 	{
 		// WBstage output size is 96, input size is 96*3 
 		u32 m = in.size();
-	    u32 n = out.size();
+		u32 n = out.size();
 		u32 offset = 0;
 
 		if (txdone && rxdone) {


### PR DESCRIPTION
The key idea is to keep the pipe flowing - even if we get a pipe_t::NOP, still transfer zeros instead of not transferring anything and congesting the pipelines.