### PR TITLE
Pipeline updates

### DIFF
--- a/Include/CDC8600.hh
+++ b/Include/CDC8600.hh
@@ -603,6 +603,24 @@ namespace CDC8600
 	    src.txdone = true;
 	}
 
+        // Zero out a stage, this is necessary when there are subpipes
+	template<u32 p, u32 q>
+	void null_transfer(u32 N, stage<p,q>& dst, u32 dstfirst)
+	{
+	    assert(dstfirst < p); assert((dstfirst + N) <= p);
+
+	    if (!dst.rxready) 		// destination ready?
+	    {
+		// destination not ready
+		dst.rxdone = false;
+		return;
+	    }
+
+	    // both source and destination are ready
+	    for (u32 i=0; i<N; i++) dst.in[dstfirst + i] = false;
+	    dst.rxdone = true;
+	}
+
 	class IFstage : public stage<0,96>
 	{
 	    private:

--- a/Src/CDC8600.cc
+++ b/Src/CDC8600.cc
@@ -593,16 +593,28 @@ namespace CDC8600
 	    mappers[0xB0] = new mapper<bb>;
 	    mappers[0x25] = new mapper<rdw>;
 	    mappers[0xF0] = new mapper<stw>;
-	    mappers[0xb1] = new mapper<cmpz>;
+	    /* mappers[0xb1] = new mapper<cmpz>; */
 	    mappers[0x0d] = new mapper<ipjkj>;
 	    mappers[0x13] = new mapper<idjkj>;
 	    mappers[0x70] = new mapper<idjki>;
 	    mappers[0x60] = new mapper<isjki>;
+
 	    mappers[0x90] = new mapper<fsub>;
 	    mappers[0x80] = new mapper<fadd>;
 	    mappers[0xA0] = new mapper<fmul>;
-		mappers[0xb3] = new mapper<agen>;
+		/* mappers[0xb3] = new mapper<agen>; */
 		mappers[0x04] = new mapper<cpkj>;
+            for (u32 i = 0x01; i < 0x10; ++i) 
+	    {
+                mappers[0xB0 + i] = mappers[0xB0];
+                mappers[0x60 + i] = mappers[0x60];
+                mappers[0x70 + i] = mappers[0x70];
+                mappers[0x80 + i] = mappers[0x80];
+                mappers[0xA0 + i] = mappers[0xA0];
+                mappers[0x90 + i] = mappers[0x90];
+                /* mappers[0xD0 + i] = mappers[0xD0]; */
+                mappers[0xF0 + i] = mappers[0xF0];
+            }
 	}
     } // namespace operations
 

--- a/Src/CDC8600.cc
+++ b/Src/CDC8600.cc
@@ -593,28 +593,16 @@ namespace CDC8600
 	    mappers[0xB0] = new mapper<bb>;
 	    mappers[0x25] = new mapper<rdw>;
 	    mappers[0xF0] = new mapper<stw>;
-	    /* mappers[0xb1] = new mapper<cmpz>; */
+	    mappers[0xb1] = new mapper<cmpz>;
 	    mappers[0x0d] = new mapper<ipjkj>;
 	    mappers[0x13] = new mapper<idjkj>;
 	    mappers[0x70] = new mapper<idjki>;
 	    mappers[0x60] = new mapper<isjki>;
-
 	    mappers[0x90] = new mapper<fsub>;
 	    mappers[0x80] = new mapper<fadd>;
 	    mappers[0xA0] = new mapper<fmul>;
-		/* mappers[0xb3] = new mapper<agen>; */
+		mappers[0xb3] = new mapper<agen>;
 		mappers[0x04] = new mapper<cpkj>;
-            for (u32 i = 0x01; i < 0x10; ++i) 
-	    {
-                mappers[0xB0 + i] = mappers[0xB0];
-                mappers[0x60 + i] = mappers[0x60];
-                mappers[0x70 + i] = mappers[0x70];
-                mappers[0x80 + i] = mappers[0x80];
-                mappers[0xA0 + i] = mappers[0xA0];
-                mappers[0x90 + i] = mappers[0x90];
-                /* mappers[0xD0 + i] = mappers[0xD0]; */
-                mappers[0xF0 + i] = mappers[0xF0];
-            }
 	}
     } // namespace operations
 


### PR DESCRIPTION
Update the pipeline to clear out inputs to subpipes if they aren't accepting input right now. This makes sure that operations are executed multiple times inside a sub-pipeline. The full run stuff doesn't work still (run into `lrutime < UINT64_MAX` assertion), but I'm fairly confident that this is correct.